### PR TITLE
Add license refrence to README.rst

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,0 @@
-
-
-## License
-
-This project is licensed under the MIT license - see the [LICENSE](https://github.com/nokia/pytest-exploratory/blob/master/LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+
+
+## License
+
+This project is licensed under the MIT license - see the [LICENSE](https://github.com/nokia/pytest-exploratory/blob/master/LICENSE).

--- a/README.rst
+++ b/README.rst
@@ -78,3 +78,9 @@ Some extra magics help navigating the test code/documentation::
     In [7]: # Fixture code
     In [8]: %pytest_fixtureinfodetail my_fixture
     ...
+
+
+License
+-------
+
+This project is licensed under the MIT license - see the [LICENSE](https://github.com/nokia/pytest-exploratory/blob/master/LICENSE).


### PR DESCRIPTION
Adds a refrence to the project license to README.md. This is considered a best-practice.